### PR TITLE
Fix en dash mapping in IO helpers

### DIFF
--- a/scripts/utils/io_helpers.py
+++ b/scripts/utils/io_helpers.py
@@ -48,8 +48,8 @@ def normalize_text(text: str) -> str:
     
     # Fix common character substitutions
     replacements = {
-        'â€"': '—',  # em dash
-        'â€"': '–',  # en dash
+        'â€”': '—',  # em dash
+        'â€“': '–',  # en dash
         'â€˜': ''',  # left single quote
         'â€™': ''',  # right single quote
         'â€œ': '"',  # left double quote


### PR DESCRIPTION
## Summary
- correct the malformed en dash entry in `normalize_text` replacements table

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`