### PR TITLE
Support custom editor prompt templates

### DIFF
--- a/scripts/editor_panel.py
+++ b/scripts/editor_panel.py
@@ -121,7 +121,8 @@ def main():
     if truncated:
         log.warning("Context tokens (%d) exceed model limit %d; analysis was truncated", token_count, model_context_limit)
 
-    rubric = textwrap.dedent("""
+    rubric_env = os.environ.get("EDITOR_PROMPT_TEMPLATE")
+    rubric = textwrap.dedent(rubric_env) if rubric_env else textwrap.dedent("""
         You are an EDITOR reviewing a REWRITE section against its RAW SOURCE.
 
         Your **primary goal** is to identify areas for improvement and formulate a

--- a/scripts/run_experiments.py
+++ b/scripts/run_experiments.py
@@ -515,10 +515,10 @@ def run_editor_panel(
     
     log.info(f"Running editor panel: {' '.join(str(arg) for arg in cmd)}")
     
-    # Set up environment with custom critic prompt if provided
+    # Set up environment with custom editor prompt if provided
     env = os.environ.copy()
     if editor_spec_content:
-        env["CRITIC_PROMPT_OVERRIDE"] = editor_spec_content
+        env["EDITOR_PROMPT_TEMPLATE"] = editor_spec_content
     
     # Set model override if provided
     if model:


### PR DESCRIPTION
## Summary
- allow editor panel to read a prompt template from `EDITOR_PROMPT_TEMPLATE`
- set `EDITOR_PROMPT_TEMPLATE` when launching editor_panel from run_experiments

## Testing
- `pytest -q`