### PR TITLE
Centralise experiment label helper

### DIFF
--- a/scripts/compare_versions.py
+++ b/scripts/compare_versions.py
@@ -31,7 +31,7 @@ from core.html_generation import generate_html_output, generate_ranking_html
 from core.elo_ranking import smart_rank_chapter_versions, pairwise_rank_chapter_versions, rank_chapter_versions
 
 # Import utilities
-from utils.paths import ROOT
+from utils.paths import ROOT, get_experiment_label
 from utils.logging_helper import get_logger
 from utils.io_helpers import read_utf8
 
@@ -525,31 +525,13 @@ def main():
             dir1_path = pathlib.Path(args.dir1)
             dir2_path = pathlib.Path(args.dir2)
             
-            # Look for 'auditions' in path to get experiment name
-            dir1_parts = dir1_path.parts
-            dir2_parts = dir2_path.parts
-            
-            dir1_name = ""
-            dir2_name = ""
-            
-            # Try to construct name like "experiment_round" from path
-            if 'auditions' in dir1_parts:
-                idx = dir1_parts.index('auditions')
-                if idx + 1 < len(dir1_parts):  # Make sure there's an experiment name after 'auditions'
-                    dir1_name = f"{dir1_parts[idx+1]}_{dir1_path.name}"
-                else:
-                    dir1_name = dir1_path.name
-            else:
-                dir1_name = dir1_path.name
-                
-            if 'auditions' in dir2_parts:
-                idx = dir2_parts.index('auditions')
-                if idx + 1 < len(dir2_parts):  # Make sure there's an experiment name after 'auditions'
-                    dir2_name = f"{dir2_parts[idx+1]}_{dir2_path.name}"
-                else:
-                    dir2_name = dir2_path.name
-            else:
-                dir2_name = dir2_path.name
+            # Derive descriptive labels for each directory
+            dir1_label = get_experiment_label(dir1_path)
+            dir2_label = get_experiment_label(dir2_path)
+
+            # Use labels to build an output filename-friendly string
+            dir1_name = dir1_label.replace(" ", "_").replace("(", "").replace(")", "")
+            dir2_name = dir2_label.replace(" ", "_").replace("(", "").replace(")", "")
             
             out_path = out_dir / f"compare_{dir1_name}_vs_{dir2_name}{output_ext}"
         

--- a/scripts/core/comparison.py
+++ b/scripts/core/comparison.py
@@ -14,6 +14,7 @@ from rich.progress import Progress, TextColumn, BarColumn, TaskProgressColumn, S
 
 from .file_loaders import load_version_text, load_texts_from_dir, load_original_text
 from .critics import get_comparison_feedback
+from utils.paths import get_experiment_label
 
 console = Console()
 
@@ -77,33 +78,9 @@ def compare_directories(dir1: pathlib.Path, dir2: pathlib.Path) -> Dict[str, Any
     dir2_name = dir2.name
     
     # Extract more descriptive names for the versions
-    # Look for 'auditions' in the path to get experiment name
-    dir1_parts = dir1.parts
-    dir2_parts = dir2.parts
-    
-    dir1_full_name = ""
-    dir2_full_name = ""
-    
-    # Try to construct a more descriptive name
-    if 'auditions' in dir1_parts:
-        idx = dir1_parts.index('auditions')
-        if idx + 1 < len(dir1_parts):  # Make sure there's an experiment name after 'auditions'
-            experiment_name = dir1_parts[idx+1]
-            dir1_full_name = f"{experiment_name} ({dir1.name})"
-        else:
-            dir1_full_name = dir1.name
-    else:
-        dir1_full_name = dir1.name
-        
-    if 'auditions' in dir2_parts:
-        idx = dir2_parts.index('auditions')
-        if idx + 1 < len(dir2_parts):  # Make sure there's an experiment name after 'auditions'
-            experiment_name = dir2_parts[idx+1]
-            dir2_full_name = f"{experiment_name} ({dir2.name})"
-        else:
-            dir2_full_name = dir2.name
-    else:
-        dir2_full_name = dir2.name
+    # Construct descriptive version labels
+    dir1_full_name = get_experiment_label(dir1)
+    dir2_full_name = get_experiment_label(dir2)
     
     console.print(f"[bold blue]Comparing directories:[/] [cyan]{dir1_full_name}[/] vs [cyan]{dir2_full_name}[/]")
     

--- a/scripts/utils/paths.py
+++ b/scripts/utils/paths.py
@@ -38,3 +38,19 @@ VOICE_DIR   = CONFIG_DIR / "voice_specs"
 # guarantee critical folders exist at import-time
 for p in (LOG_DIR,):
     p.mkdir(exist_ok=True)
+
+
+def get_experiment_label(path: Path) -> str:
+    """Return a human-friendly label for an experiment directory.
+
+    If *path* contains ``auditions/<experiment>/round_N`` (or ``final``), the
+    label will be ``"<experiment> (round_N)"``. If no experiment name is
+    detected, the directory name is returned unchanged.
+    """
+    parts = Path(path).parts
+    if "auditions" in parts:
+        idx = parts.index("auditions")
+        if idx + 1 < len(parts):
+            experiment = parts[idx + 1]
+            return f"{experiment} ({Path(path).name})"
+    return Path(path).name


### PR DESCRIPTION
## Notes
- Added `get_experiment_label` utility to derive readable labels for audition directories.
- Replaced duplicated directory-name logic in comparison helpers with the new function.
- Existing behaviour when no experiment name is found is preserved.

## Testing
- `pytest -q` *(fails: ModuleNotFoundError in tests)*